### PR TITLE
Change retail toc detection method to not get beta patch.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -45,7 +45,7 @@ elif [[ -z "$interfaceVersions" ]]; then
 fi
 
 # map interface version to variables based on game version
-retailInterfaceVersion="$(jq -r --arg v "$retailVersion" '.[] | select(.id == $v) | .interface' <<< "$interfaceVersions")"
+retailInterfaceVersion="$(jq -r --arg v "$retailVersion" '.[] | select(.game == "Retail" and .default  == true) | .interface' <<< "$interfaceVersions")"
 classicInterfaceVersion="$(jq -r --arg v "$classicVersion" '.[] | select(.id == $v) | .interface' <<< "$interfaceVersions")"
 bccInterfaceVersion="$(jq -r --arg v "$bccVersion" '.[] | select(.id == $v) | .interface' <<< "$interfaceVersions")"
 


### PR DESCRIPTION
I noticed that the updated will pull the beta patch as the primary version for retail. 

This change uses the default retail build from wowinterface instead, which seems to return the desired version. 